### PR TITLE
Changed ApiClient.SendMessageCommandAsync

### DIFF
--- a/Emby.ApiClient/ApiClient.cs
+++ b/Emby.ApiClient/ApiClient.cs
@@ -1163,20 +1163,17 @@ namespace Emby.ApiClient
 
         public Task SendMessageCommandAsync(string sessionId, MessageCommand command)
         {
-            var cmd = new GeneralCommand
+            var messageCmd = new MessageCommand
             {
-                Name = "DisplayMessage"
+                Header = command.Header,
+                Text = command.Text,
+                TimeoutMs = command.TimeoutMs
             };
 
-            cmd.Arguments["Header"] = command.Header;
-            cmd.Arguments["Text"] = command.Text;
 
-            if (command.TimeoutMs.HasValue)
-            {
-                cmd.Arguments["Timeout"] = command.TimeoutMs.Value.ToString(CultureInfo.InvariantCulture);
-            }
+            var url = GetApiUrl($"Sessions/{sessionId}/Message");
 
-            return SendCommandAsync(sessionId, cmd);
+            return PostAsync<MessageCommand, EmptyRequestResult>(url, messageCmd, CancellationToken.None);
         }
 
         /// <summary>


### PR DESCRIPTION
Changed ApiClient.SendMessageCommandAsync implementation send data to send in the POST body, as that is how the
Jellyfin SessionController on the server now accepts data.

Resolves: jellyfin/jellyfin#5628